### PR TITLE
add BASIC_AUTH_PASSWORD for application_controller.rb

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
+  http_basic_authenticate_with :name => ENV['BASIC_AUTH_USERNAME'], :password => ENV['BASIC_AUTH_PASSWORD'] if Rails.env == "production"
 
   def after_sign_in_path_for(resource)
     redirect_back(fallback_location: root_path)


### PR DESCRIPTION
#WHAT
BASIC認証の実装。

#WHY
必須機能の為。
